### PR TITLE
feat: Get username on deployment and send to webhook

### DIFF
--- a/src/components/DeploymentConfig.tsx
+++ b/src/components/DeploymentConfig.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { motion } from 'framer-motion';
-import { Settings, Play, Trash2 } from 'lucide-react';
+import { Settings, Play, Trash2, User } from 'lucide-react';
 
 interface DeploymentConfig {
   cloudProvider: string;
   appType: string;
   region: string;
+  username: string;
 }
 
 interface DeploymentConfigProps {
@@ -19,7 +20,8 @@ const DeploymentConfigPanel = ({ onDeploy, isDeploying, onDestroy, hasDeployment
   const [config, setConfig] = React.useState<DeploymentConfig>({
     cloudProvider: 'AWS',
     appType: 'Web Application',
-    region: 'us-east-1'
+    region: 'us-east-1',
+    username: ''
   });
 
   const cloudProviders = [
@@ -51,6 +53,22 @@ const DeploymentConfigPanel = ({ onDeploy, isDeploying, onDestroy, hasDeployment
       </div>
 
       <div className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-3">
+            Your Name
+          </label>
+          <div className="relative flex items-center">
+            <User className="w-5 h-5 text-gray-400 absolute left-3 z-10" />
+            <input
+              type="text"
+              placeholder="Enter your name"
+              value={config.username}
+              onChange={(e) => setConfig(prev => ({ ...prev, username: e.target.value }))}
+              className="w-full p-3 pl-10 bg-gray-700 border border-gray-600 rounded-lg text-white focus:border-cyan-500 focus:outline-none relative"
+              disabled={isDeploying}
+            />
+          </div>
+        </div>
         <div>
           <label className="block text-sm font-medium text-gray-300 mb-3">
             Cloud Provider

--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -8,6 +8,7 @@ interface DeploymentConfig {
   cloudProvider: string;
   appType: string;
   region: string;
+  username: string;
 }
 
 interface DeploymentResult {
@@ -30,7 +31,22 @@ const LiveDemoPage = () => {
     setProgress(0);
     setDeploymentResult(null);
 
+    try {
+      await fetch('https://n8n-service-mxvj.onrender.com/webhook-test/hashir', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username: config.username }),
+      });
+      setLogs(prev => [...prev, '[INFO] User information sent successfully.']);
+    } catch (err) {
+      console.error('Failed to send user information:', err);
+      setLogs(prev => [...prev, '[ERROR] Failed to send user information.']);
+    }
+
     const deploymentSteps = [
+      `[INFO] Starting deployment for user: ${config.username}`,
       `[INFO] Starting deployment to ${config.cloudProvider}`,
       `[INFO] Application type: ${config.appType}`,
       `[INFO] Target region: ${config.region}`,


### PR DESCRIPTION
This change adds a new input field to the deployment configuration to get the username. When a deployment is initiated, the username is sent to a webhook at `https://n8n-service-mxvj.onrender.com/webhook-test/hashir` via a POST request.

This addresses the user's request to track who initiates deployments in the live demo.