### PR TITLE
fix(pusher): Correct invalid characters in channel and event names

### DIFF
--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -44,11 +44,11 @@ const listenForDeploymentStatus = () => {
   const pusher = new Pusher('dbadd46115526a98ea56', {
     cluster: 'ap2',
   });
-  const channel = pusher.subscribe('my‑channel');
+  const channel = pusher.subscribe('my-channel');
 
-  setLogs(prev => [...prev, '[INFO] Subscribed to channel: my‑channel']);
+  setLogs(prev => [...prev, '[INFO] Subscribed to channel: my-channel']);
   
-  channel.bind('my‑event', (data: any) => {
+  channel.bind('my-event', (data: any) => {
     console.log('Pusher event received:', data);
     try {
       const parsedData = JSON.parse(data);


### PR DESCRIPTION
The Pusher subscription was failing because the channel name ('my‑channel') and event name ('my‑event') were using a non-standard, non-breaking hyphen (U+2011) instead of the standard ASCII hyphen (U+002D).

This change replaces the invalid hyphens with standard ones to allow the Pusher subscription to succeed. This resolves the `PusherError: Invalid channel name (bad chars)` error.