### PR TITLE
refactor(deploy): Remove simulation and drive UI from Pusher events

### DIFF
--- a/src/components/DeploymentStatus.tsx
+++ b/src/components/DeploymentStatus.tsx
@@ -4,11 +4,8 @@ import { Clock, CheckCircle, XCircle, ExternalLink } from 'lucide-react';
 
 interface DeploymentResult {
   appUrl: string;
-  grafanaUrl: string;
-  kibanaUrl: string; // Keep for type safety, but remove from UI
-  n8nStatus?: string;
-  n8nAppUrl?: string;
-  n8nMonitorUrl?: string;
+  monitorUrl: string;
+  status?: string;
 }
 
 interface DeploymentStatusProps {
@@ -101,7 +98,7 @@ const DeploymentStatus = ({ status, progress, result }: DeploymentStatusProps) =
                 </div>
               </div>
               <a
-                href={result.n8nAppUrl || result.appUrl}
+                href={result.appUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm font-medium transition-colors"
@@ -117,11 +114,11 @@ const DeploymentStatus = ({ status, progress, result }: DeploymentStatusProps) =
                 <motion.div className="w-5 h-5 text-orange-400">📊</motion.div>
                 <div>
                   <div className="font-medium text-white">Monitoring Dashboard</div>
-                  <div className="text-sm text-gray-400">Grafana metrics and alerts</div>
+                  <div className="text-sm text-gray-400">Real-time application metrics</div>
                 </div>
               </div>
               <a
-                href={result.n8nMonitorUrl || result.grafanaUrl}
+                href={result.monitorUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="px-4 py-2 bg-orange-600 hover:bg-orange-700 text-white rounded-lg text-sm font-medium transition-colors"
@@ -130,28 +127,6 @@ const DeploymentStatus = ({ status, progress, result }: DeploymentStatusProps) =
               </a>
             </div>
           </div>
-
-          {result.n8nStatus && (
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5, delay: 0.4 }}
-              className="mt-6"
-            >
-              <h4 className="text-lg font-semibold text-white mb-4">
-                n8n Deployment Status
-              </h4>
-              <div className="bg-gray-700 rounded-lg p-4 border border-gray-600">
-                <div className="flex items-center space-x-3">
-                  <div className="w-5 h-5 text-teal-400">🚀</div>
-                  <div>
-                    <div className="font-medium text-white">Status</div>
-                    <div className="text-sm text-gray-400">{result.n8nStatus}</div>
-                  </div>
-                </div>
-              </div>
-            </motion.div>
-          )}
         </motion.div>
       )}
 


### PR DESCRIPTION
The live deployment page was using a fake, simulated deployment process which caused the UI to display placeholder data before the real deployment was complete.

This commit refactors the entire process:

- The simulated deployment steps in `handleDeploy` have been removed.
- The application now starts listening for a Pusher event immediately upon deployment initiation.
- All UI state updates (e.g., setting result URLs, success/error status) are now driven exclusively by the data received from the Pusher event.
- The `DeploymentResult` interface and the `DeploymentStatus` component have been simplified to remove legacy code related to the simulation.