### PR TITLE
fix(deploy): Make Pusher event parsing robust

### DIFF
--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -48,7 +48,13 @@ const listenForDeploymentStatus = () => {
   channel.bind('my-event', (data: any) => {
     console.log('Pusher event received:', data);
     try {
-      const parsedData = JSON.parse(data);
+      let parsedData;
+      if (typeof data === 'string') {
+        parsedData = JSON.parse(data);
+      } else {
+        parsedData = data;
+      }
+
       setLogs(prev => [...prev, `[SUCCESS] Received trigger with status: ${parsedData.status}`]);
 
       setDeploymentResult({


### PR DESCRIPTION
The application was encountering a `JSON.parse` error when the data received from the Pusher event was not a valid JSON string (e.g., if it was already a JavaScript object).

This change makes the event handler more robust by checking if the incoming data is a string before attempting to parse it. If the data is already an object, it is used directly. This prevents parsing errors and allows the frontend to correctly handle events regardless of whether the data payload is a string or an object.