### PR TITLE
fix(deploy): Correctly parse nested Pusher event data

### DIFF
--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -45,15 +45,11 @@ const listenForDeploymentStatus = () => {
 
   setLogs(prev => [...prev, '[INFO] Subscribed to channel: my-channel']);
   
-  channel.bind('my-event', (data: any) => {
-    console.log('Pusher event received:', data);
+  channel.bind('my-event', (event: any) => {
+    console.log('Pusher event received:', event);
     try {
-      let parsedData;
-      if (typeof data === 'string') {
-        parsedData = JSON.parse(data);
-      } else {
-        parsedData = data;
-      }
+      // The actual data payload is a string inside the 'data' property of the event object.
+      const parsedData = JSON.parse(event.data);
 
       setLogs(prev => [...prev, `[SUCCESS] Received trigger with status: ${parsedData.status}`]);
 

--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -47,6 +47,7 @@ const listenForDeploymentStatus = () => {
   
   channel.bind('my-event', (event: any) => {
     console.log('Pusher event received:', event);
+    setLogs(prev => [...prev, 'Pusher event received']);
     try {
       // The actual data payload is a string inside the 'data' property of the event object.
       const parsedData = JSON.parse(event.data);


### PR DESCRIPTION
The Pusher event handler was attempting to parse the top-level event object, instead of the nested `data` property which contains the actual JSON string.

This was causing `parsedData.status` to be `undefined`.

This commit corrects the logic to access `event.data` and parse its value, which resolves the issue and allows the application to correctly process the trigger data.