### PR TITLE
feat(config): Use environment variables for Pusher credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Pusher Credentials
+# IMPORTANT: For the client-side, environment variables must be prefixed with VITE_
+VITE_PUSHER_APP_KEY=your_pusher_app_key
+VITE_PUSHER_CLUSTER=your_pusher_cluster

--- a/src/pages/LiveDemoPage.tsx
+++ b/src/pages/LiveDemoPage.tsx
@@ -38,8 +38,17 @@ const LiveDemoPage = () => {
 const listenForDeploymentStatus = () => {
   setLogs(prev => [...prev, '[INFO] Connecting to Pusher...']);
 
-  const pusher = new Pusher('dbadd46115526a98ea56', {
-    cluster: 'ap2',
+  const appKey = import.meta.env.VITE_PUSHER_APP_KEY;
+  const cluster = import.meta.env.VITE_PUSHER_CLUSTER;
+
+  if (!appKey || !cluster) {
+    console.error('Pusher environment variables not set.');
+    setLogs(prev => [...prev, '[ERROR] Pusher configuration is missing.']);
+    return;
+  }
+
+  const pusher = new Pusher(appKey, {
+    cluster: cluster,
   });
   const channel = pusher.subscribe('my-channel');
 
@@ -48,8 +57,6 @@ const listenForDeploymentStatus = () => {
   channel.bind('my-event', (event: any) => {
     console.log('Pusher event received:', event);
     setLogs(prev => [...prev, 'Pusher event received']);
- 
-  
     try {
       // The actual data payload is a string inside the 'data' property of the event object.
       const parsedData = JSON.parse(event.data);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_PUSHER_APP_KEY: string;
+  readonly VITE_PUSHER_CLUSTER: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
This commit refactors the Pusher integration to pull credentials from environment variables instead of using hardcoded values.

Changes:
- Added `.env` and `.env.example` files for environment variable management.
- Updated `.gitignore` to ensure `.env` is not committed.
- Modified `src/pages/LiveDemoPage.tsx` to use `import.meta.env.VITE_PUSHER_APP_KEY` and `import.meta.env.VITE_PUSHER_CLUSTER`.
- Added TypeScript definitions for the new environment variables in `src/vite-env.d.ts`.

This improves security and makes the application more configurable.